### PR TITLE
A way to set plugin version, vendor name and url

### DIFF
--- a/teamcity-plugin/src/main/resources/archetype-resources/build/pom.xml
+++ b/teamcity-plugin/src/main/resources/archetype-resources/build/pom.xml
@@ -1,3 +1,4 @@
+#set( $prefix = '${teamcity.' )
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -5,6 +6,9 @@
   <packaging>pom</packaging>
   <properties>
       <maven.build.timestamp.format>yyyyddMMHHmmss</maven.build.timestamp.format>
+      <teamcity.${rootArtifactId}.plugin.version>snapshot-${maven.build.timestamp}</teamcity.${rootArtifactId}.plugin.version>
+      <teamcity.${rootArtifactId}.plugin.vendorName>Plugin vendor name</teamcity.${rootArtifactId}.plugin.vendorName>
+      <teamcity.${rootArtifactId}.plugin.vendorUrl>Plugin vendor URL</teamcity.${rootArtifactId}.plugin.vendorUrl>
   </properties>
   <dependencies>
       <dependency>
@@ -43,7 +47,15 @@
                 <replacements>
                     <replacement>
                         <token>@Version@</token>
-                        <value>snapshot-${maven.build.timestamp}</value>
+                        <value>$prefix${rootArtifactId}.plugin.version}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorName@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorName}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorURL@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorUrl}</value>
                     </replacement>
                 </replacements>                        
             </configuration>

--- a/teamcity-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
+++ b/teamcity-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
@@ -8,8 +8,8 @@
     <download-url>Plugin download URL</download-url>
     <email>Plugin author e-mail</email>
     <vendor>
-      <name>Plugin vendor name</name>
-      <url>Plugin vendor URL</url>
+      <name>@VendorName@</name>
+      <url>@VendorURL@</url>
       <logo>Plugin vendor logo URL</logo>
     </vendor>
   </info>

--- a/teamcity-sample-plugin/src/main/resources/archetype-resources/build/pom.xml
+++ b/teamcity-sample-plugin/src/main/resources/archetype-resources/build/pom.xml
@@ -1,3 +1,4 @@
+#set( $prefix = '${teamcity.' )
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -5,6 +6,9 @@
   <packaging>pom</packaging>
   <properties>
       <maven.build.timestamp.format>yyyyddMMHHmmss</maven.build.timestamp.format>
+      <teamcity.${rootArtifactId}.plugin.version>snapshot-${maven.build.timestamp}</teamcity.${rootArtifactId}.plugin.version>
+      <teamcity.${rootArtifactId}.plugin.vendorName>Plugin vendor name</teamcity.${rootArtifactId}.plugin.vendorName>
+      <teamcity.${rootArtifactId}.plugin.vendorUrl>Plugin vendor URL</teamcity.${rootArtifactId}.plugin.vendorUrl>
   </properties>
   <dependencies>
       <dependency>
@@ -43,7 +47,15 @@
                 <replacements>
                     <replacement>
                         <token>@Version@</token>
-                        <value>snapshot-${maven.build.timestamp}</value>
+                        <value>$prefix${rootArtifactId}.plugin.version}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorName@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorName}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorURL@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorUrl}</value>
                     </replacement>
                 </replacements>                        
             </configuration>

--- a/teamcity-sample-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
+++ b/teamcity-sample-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
@@ -8,8 +8,8 @@
     <download-url>Plugin download URL</download-url>
     <email>Plugin author e-mail</email>
     <vendor>
-      <name>Plugin vendor name</name>
-      <url>Plugin vendor URL</url>
+      <name>@VendorName@</name>
+      <url>@VendorURL@</url>
       <logo>Plugin vendor logo URL</logo>
     </vendor>
   </info>

--- a/teamcity-server-plugin/src/main/resources/archetype-resources/build/pom.xml
+++ b/teamcity-server-plugin/src/main/resources/archetype-resources/build/pom.xml
@@ -1,3 +1,4 @@
+#set( $prefix = '${teamcity.' )
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -5,6 +6,9 @@
   <packaging>pom</packaging>
   <properties>
       <maven.build.timestamp.format>yyyyddMMHHmmss</maven.build.timestamp.format>
+      <teamcity.${rootArtifactId}.plugin.version>snapshot-${maven.build.timestamp}</teamcity.${rootArtifactId}.plugin.version>
+      <teamcity.${rootArtifactId}.plugin.vendorName>Plugin vendor name</teamcity.${rootArtifactId}.plugin.vendorName>
+      <teamcity.${rootArtifactId}.plugin.vendorUrl>Plugin vendor URL</teamcity.${rootArtifactId}.plugin.vendorUrl>
   </properties>
   <dependencies>
       <dependency>
@@ -33,7 +37,15 @@
                 <replacements>
                     <replacement>
                         <token>@Version@</token>
-                        <value>snapshot-${maven.build.timestamp}</value>
+                        <value>$prefix${rootArtifactId}.plugin.version}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorName@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorName}</value>
+                    </replacement>
+                    <replacement>
+                        <token>@VendorURL@</token>
+                        <value>$prefix${rootArtifactId}.plugin.vendorUrl}</value>
                     </replacement>
                 </replacements>                        
             </configuration>

--- a/teamcity-server-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
+++ b/teamcity-server-plugin/src/main/resources/archetype-resources/teamcity-plugin.xml
@@ -8,8 +8,8 @@
     <download-url>Plugin download URL</download-url>
     <email>Plugin author e-mail</email>
     <vendor>
-      <name>Plugin vendor name</name>
-      <url>Plugin vendor URL</url>
+      <name>@VendorName@</name>
+      <url>@VendorURL@</url>
       <logo>Plugin vendor logo URL</logo>
     </vendor>
   </info>


### PR DESCRIPTION
Introduced 3 proprties:
- teamcity.${artifactId}.plugin.version
- teamcity.${artifactId}.plugin.vendorName
- teamcity.${artifactId}.plugin.vendorUrl

where ${artifactId} is project's artifactId. These properties could be defined during the project build to specify plugin version, vendor name and vendor url. eg:

mvn package -Dteamcity.sample.plugin.version=1

Unset property will use default value. 
